### PR TITLE
feat: SEO改善項目を実装

### DIFF
--- a/.serena/memories/seo_improvements.md
+++ b/.serena/memories/seo_improvements.md
@@ -12,6 +12,8 @@
 
 ### 1. RSS Feedの情報補完
 
+**状態**: ✅ **実装済み** (2025-11-13)
+
 **現状の問題**
 - `src/app/rss.xml/route.ts` のtitleとdescriptionが"TODO"のまま
 
@@ -36,6 +38,8 @@
 
 ### 2. RSS Feed画像追加
 
+**状態**: ✅ **実装済み** (2025-11-13)
+
 **現状**
 - RSSに画像情報が含まれていない
 
@@ -58,6 +62,8 @@
 
 ### 3. OGP locale設定追加
 
+**状態**: ✅ **実装済み** (2025-11-13)
+
 **現状**
 - OGPにlocale情報が含まれていない
 
@@ -79,6 +85,8 @@ openGraph: {
 ---
 
 ### 4. Canonical URL設定
+
+**状態**: ✅ **実装済み** (2025-11-13)
 
 **現状**
 - ブログ記事ページにcanonical URLが設定されていない
@@ -170,6 +178,8 @@ export async function generateMetadata({ params }: BlogPostPageProps) {
 
 ### 7. 記事詳細ページのrobots設定
 
+**状態**: ✅ **実装済み** (2025-11-13)
+
 **現状**
 - 記事ページに画像プレビュー用のrobots設定がない
 
@@ -198,6 +208,8 @@ export async function generateMetadata({ params }: BlogPostPageProps) {
 ---
 
 ### 8. OGP site_name追加
+
+**状態**: ✅ **実装済み** (2025-11-13)
 
 **現状**
 - openGraphに`siteName`が設定されていない

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -30,18 +30,28 @@ export async function generateMetadata({ params }: BlogPostPageProps) {
   return {
     title: post.metadata.title,
     description: post.metadata.description,
+    alternates: {
+      canonical: absoluteUrl(`/blog/${post.slug}`),
+    },
     openGraph: {
       title: post.metadata.title,
       description: post.metadata.description,
       type: 'article',
       url: absoluteUrl(`/blog/${post.slug}`),
       images: [absoluteUrl(`/blog/ogp/${post.slug}`)],
+      locale: 'ja_JP',
+      siteName: 'sui-portfolio',
     },
     twitter: {
       card: 'summary_large_image',
       title: post.metadata.title,
       description: post.metadata.description,
       images: [absoluteUrl(`/blog/ogp/${post.slug}`)],
+    },
+    robots: {
+      index: true,
+      follow: true,
+      'max-image-preview': 'large',
     },
   };
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,6 +21,8 @@ export const metadata: Metadata = {
     title: siteConfig.name,
     description: siteConfig.description,
     images: [siteConfig.ogImage],
+    locale: 'ja_JP',
+    siteName: siteConfig.name,
   },
   twitter: {
     title: siteConfig.name,

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -9,12 +9,17 @@ export async function GET() {
   const rssXml = `
     <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
       <channel>
-        <title>TODO</title>
+        <title>${siteConfig.name}</title>
         <link>${baseUrl}</link>
-        <description>TODO</description>
+        <description>${siteConfig.description}</description>
         <language>ja</language>
         <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
         <atom:link href="${baseUrl}/rss.xml" rel="self" type="application/rss+xml"/>
+        <image>
+          <url>${baseUrl}/favicon.png</url>
+          <title>${siteConfig.name}</title>
+          <link>${baseUrl}</link>
+        </image>
         ${posts
           .map((post) => {
             return `


### PR DESCRIPTION
- RSS Feedの情報補完 (title/descriptionをsiteConfigから取得)
- RSS Feed画像追加 (favicon.pngを指定)
- OGP locale設定追加 (ja_JP)
- Canonical URL設定 (ブログ記事ページ)
- OGP site_name追加 (layout.tsxとblog/[slug]/page.tsx)
- 記事詳細ページのrobots設定 (max-image-preview: large)

これらの変更により、以下の効果が期待できます：
- RSS購読者への情報表示改善
- SNS共有時の言語情報明示とサイト名表示
- 検索エンジンへの正規URL明示
- Google検索結果での大きな画像プレビュー表示