### PR TITLE
feat: icon_urlフィールドを活用したブログアイコン表示機能を修正

### DIFF
--- a/contents/blog/2025-03-17_add-blog-to-portfolio.md
+++ b/contents/blog/2025-03-17_add-blog-to-portfolio.md
@@ -3,7 +3,7 @@ title: ポートフォリオにブログページを追加しました
 date: 2025-03-17
 description: ポートフォリオサイトにブログページを追加しました。今後はZennやQiitaで投稿していた内容を、こちらに集約する想定です。
 icon: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Party%20popper/Flat/party_popper_flat.svg
-icon_url:
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Party%20popper/Flat/party_popper_flat.svg
 tags:
   - ポートフォリオ
   - ブログ

--- a/contents/blog/2025-03-20_messaging-api-github-pr.md
+++ b/contents/blog/2025-03-20_messaging-api-github-pr.md
@@ -2,7 +2,7 @@
 title: LINE Messaging APIから自動でGitHubにPRを発行する
 date: 2025-03-20
 icon: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Fire/Flat/fire_flat.svg
-icon_url:
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Fire/Flat/fire_flat.svg
 slug: messaging-api-github-pr
 tags:
   - LINE Messaging API

--- a/contents/blog/2025-03-21_noto-sans-jp-safari-mincho.md
+++ b/contents/blog/2025-03-21_noto-sans-jp-safari-mincho.md
@@ -2,7 +2,7 @@
 title: NotoSansJP使ってるのにSafariのフォントが明朝体になる
 date: 2025-03-21
 icon: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Pencil/Flat/pencil_flat.svg
-icon_url:
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Pencil/Flat/pencil_flat.svg
 slug: noto-sans-jp-safari-mincho
 tags:
   - Tailwind CSS

--- a/contents/blog/2025-03-22_cloudflare-get-domain-vercel.md
+++ b/contents/blog/2025-03-22_cloudflare-get-domain-vercel.md
@@ -2,7 +2,7 @@
 title: Vercelで独自ドメインを設定する
 date: 2025-03-22
 icon: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Water%20wave/Flat/water_wave_flat.svg
-icon_url:
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Water%20wave/Flat/water_wave_flat.svg
 slug: cloudflare-get-domain-vercel
 tags:
   - Cloudflare

--- a/contents/blog/2025-03-25_notion-images-put-cloudflare.md
+++ b/contents/blog/2025-03-25_notion-images-put-cloudflare.md
@@ -2,7 +2,7 @@
 title: Notionの画像(S3)をCloudflare R2に格納する
 date: 2025-03-25
 icon: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Framed%20picture/Flat/framed_picture_flat.svg
-icon_url:
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Framed%20picture/Flat/framed_picture_flat.svg
 slug: notion-images-put-cloudflare
 tags:
   - Cloudflare Workers

--- a/contents/blog/2025-03-28_response-header-web-check-list.md
+++ b/contents/blog/2025-03-28_response-header-web-check-list.md
@@ -2,7 +2,7 @@
 title: 「Webサービス公開前のチェックリスト」にあるレスポンスヘッダの内容を調べてみる
 date: 2025-03-28
 icon: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Ambulance/Flat/ambulance_flat.svg
-icon_url:
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Ambulance/Flat/ambulance_flat.svg
 slug: response-header-web-check-list
 tags:
   - セキュリティ

--- a/contents/blog/2025-03-30_ios-kawaii-emoji.md
+++ b/contents/blog/2025-03-30_ios-kawaii-emoji.md
@@ -2,7 +2,7 @@
 title: iOSでもWindowsと同じ絵文字を表示したい！
 date: 2025-03-30
 icon: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Smiling%20face%20with%20halo/Flat/smiling_face_with_halo_flat.svg
-icon_url:
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Smiling%20face%20with%20halo/Flat/smiling_face_with_halo_flat.svg
 slug: ios-kawaii-emoji
 tags:
   - 絵文字

--- a/contents/blog/2025-04-10_chinchillo-mcp-server.md
+++ b/contents/blog/2025-04-10_chinchillo-mcp-server.md
@@ -2,7 +2,7 @@
 title: チンチロをするMCPサーバーを作ってみる
 date: 2025-04-10
 icon: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Game%20die/Flat/game_die_flat.svg
-icon_url:
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Game%20die/Flat/game_die_flat.svg
 slug: chinchillo-mcp-server
 tags:
   - MCP

--- a/contents/blog/2025-04-24_vscode-github-copilot-multiple-prompt.md
+++ b/contents/blog/2025-04-24_vscode-github-copilot-multiple-prompt.md
@@ -2,7 +2,7 @@
 title: GitHub Copilotもルールを強制させる
 date: 2025-04-24
 icon: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Airplane%20departure/Flat/airplane_departure_flat.svg
-icon_url:
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Airplane%20departure/Flat/airplane_departure_flat.svg
 slug: vscode-github-copilot-multiple-prompt
 tags:
   - GitHub

--- a/contents/blog/2025-05-07_kinpatsu-heroine-honox.md
+++ b/contents/blog/2025-05-07_kinpatsu-heroine-honox.md
@@ -2,7 +2,7 @@
 title: 『ないなら作ればいいじゃない』HonoXで金髪ヒロインしか乗ってないアニメ専門サイトを作った話
 date: 2025-05-07
 icon: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Fire/Flat/fire_flat.svg
-icon_url:
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Fire/Flat/fire_flat.svg
 slug: kinpatsu-heroine-honox
 tags:
   - HonoX

--- a/contents/blog/2025-06-29_honox-ssr-hydration-issue.md
+++ b/contents/blog/2025-06-29_honox-ssr-hydration-issue.md
@@ -2,7 +2,7 @@
 title: HonoXにおけるSSRとクライアントサイドHydrationの同期問題とその解決策
 date: 2025-06-29
 icon: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Cloud%20with%20rain/Flat/cloud_with_rain_flat.svg
-icon_url:
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Cloud%20with%20rain/Flat/cloud_with_rain_flat.svg
 slug: honox-ssr-hydration-issue
 tags:
   - HonoX

--- a/contents/blog/2025-07-13_cc-vault-curation-media.md
+++ b/contents/blog/2025-07-13_cc-vault-curation-media.md
@@ -2,7 +2,7 @@
 title: CC-VaultというClaude Code専用のキュレーションメディアを作った
 date: 2025-07-13
 icon: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Lemon/Flat/lemon_flat.svg
-icon_url:
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Lemon/Flat/lemon_flat.svg
 slug: cc-vault-curation-media
 tags:
   - Claude

--- a/contents/blog/2025-09-21_nextjs-cloudflare-devcontainer-glibc-issue.md
+++ b/contents/blog/2025-09-21_nextjs-cloudflare-devcontainer-glibc-issue.md
@@ -2,7 +2,7 @@
 title: Next.js + OpenNext.js をdevcontainerで起動しようとしたときにハマったこと
 date: 2025-09-21
 icon: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Wrench/Flat/wrench_flat.svg
-icon_url:
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Wrench/Flat/wrench_flat.svg
 slug: nextjs-cloudflare-devcontainer-glibc-issue
 tags:
   - Next.js

--- a/contents/blog/2025-11-15_markdown-migrate-sample-blog.md
+++ b/contents/blog/2025-11-15_markdown-migrate-sample-blog.md
@@ -3,7 +3,7 @@ title: Markdown移行後のサンプルブログ
 slug: markdown-migrate-sample-blog
 date: 2025-11-15
 description: Markdown移行後のサンプルブログです。出力されている値を確認するのが目的です。
-icon: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Airplane%20departure/Flat/airplane_departure_flat.svg
+icon: 💉
 icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Syringe/Flat/syringe_flat.svg
 tags:
   - ClaudeCode

--- a/scripts/update-blog-icon.ts
+++ b/scripts/update-blog-icon.ts
@@ -87,20 +87,22 @@ async function updateBlogIconUrl({
     return `ℹ️  Skipped: ${path.basename(filePath)} (icon_url already exists)`;
   }
 
-  // iconフィールドが既にURLの場合はスキップ
+  let iconUrl: string;
+
+  // iconフィールドが既にURLの場合はそのまま使用
   if (
     typeof frontmatter.icon === 'string' &&
     frontmatter.icon.startsWith('http')
   ) {
-    return `ℹ️  Skipped: ${path.basename(filePath)} (icon is already a URL)`;
-  }
+    iconUrl = frontmatter.icon;
+  } else {
+    // 絵文字をFluentUI EmojiのURLに変換
+    iconUrl = convertEmojiToFluentUrl({ icon: frontmatter.icon });
 
-  // 絵文字をFluentUI EmojiのURLに変換
-  const iconUrl = convertEmojiToFluentUrl({ icon: frontmatter.icon });
-
-  // 変換できなかった場合（絵文字データが見つからない）はスキップ
-  if (iconUrl === frontmatter.icon) {
-    return `⚠️  Warning: ${path.basename(filePath)} (could not convert emoji: ${frontmatter.icon})`;
+    // 変換できなかった場合（絵文字データが見つからない）はスキップ
+    if (iconUrl === frontmatter.icon) {
+      return `⚠️  Warning: ${path.basename(filePath)} (could not convert emoji: ${frontmatter.icon})`;
+    }
   }
 
   // icon_url:の値を更新（YAMLフォーマットを保持）

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -76,6 +76,11 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
   // 目次を生成
   const tableOfContents = extractTOC(post.rawContent);
 
+  // icon_urlを優先、なければiconのURLを使用
+  const displayUrl =
+    post.metadata.icon_url ||
+    (post.metadata.icon?.startsWith('https://') ? post.metadata.icon : null);
+
   // 構造化データ (JSON-LD) の生成
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -114,14 +119,18 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
 
       <article className='min-h-[500px]'>
         {/* Icon */}
-        {post.metadata.icon && (
+        {(displayUrl || post.metadata.icon) && (
           <div className='mb-6 flex justify-center'>
-            <Image
-              src={post.metadata.icon}
-              alt={`Icon for ${post.metadata.title}`}
-              width={80}
-              height={80}
-            />
+            {displayUrl ? (
+              <Image
+                src={displayUrl}
+                alt={`Icon for ${post.metadata.title}`}
+                width={80}
+                height={80}
+              />
+            ) : (
+              <div className='text-6xl'>{post.metadata.icon}</div>
+            )}
           </div>
         )}
 

--- a/src/components/feature/content/blog-card.tsx
+++ b/src/components/feature/content/blog-card.tsx
@@ -50,6 +50,11 @@ export function BlogCard({ data }: BlogCardProps) {
   const dateISO = new Date(metadata.date).toISOString();
   const formattedDate = formatDate(metadata.date);
 
+  // icon_urlを優先、なければiconのURLを使用
+  const displayUrl =
+    metadata.icon_url ||
+    (metadata.icon?.startsWith('https://') ? metadata.icon : null);
+
   return (
     <Link
       href={`/blog/${slug}`}
@@ -62,10 +67,10 @@ export function BlogCard({ data }: BlogCardProps) {
       <div className='flex flex-row items-start gap-4'>
         {/* Icon Section */}
         <div className='shrink-0'>
-          {metadata.icon?.startsWith('https://') ? (
+          {displayUrl ? (
             <Image
               className='size-[60px] object-cover p-1'
-              src={metadata.icon}
+              src={displayUrl}
               alt={metadata.title}
               width={60}
               height={60}

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -16,8 +16,10 @@ export type BlogPost = MarkdownData<{
   thumbnail?: string;
   /** 記事に付与されたタグの配列 */
   tags?: string[];
-  /** 記事のアイコン画像のURL */
+  /** 記事のアイコン（絵文字またはURL） */
   icon?: string;
+  /** 絵文字変換後のアイコンURL（FluentUI Emoji） */
+  icon_url?: string;
 }>;
 
 /**


### PR DESCRIPTION
- BlogPost型にicon_urlフィールドを追加
- BlogCardとpage.tsxでicon_urlを優先的に使用するロジックを実装
- update-blog-icon.tsでiconがURLの場合も処理できるように修正
- 全ブログファイルのicon_urlを生成（絵文字→FluentUI Emoji URL変換）
- iconフィールドは絵文字、icon_urlフィールドは変換後のURLという役割分担を明確化