### PR TITLE
feat: 見出しに#記号を表示し、目次をH2までに制限

### DIFF
--- a/src/components/feature/content/table-of-contents.tsx
+++ b/src/components/feature/content/table-of-contents.tsx
@@ -15,11 +15,11 @@ type TableOfContentsProps = {
 /**
  * 記事の目次を表示するコンポーネント
  *
- * このコンポーネントはh2とh3要素から階層構造を持った目次を生成し、記事の上部に表示します。
+ * このコンポーネントはh2要素から目次を生成し、記事の上部に表示します。
  * 目次項目をクリックすると、通常のアンカータグを使用してNext.jsのルーターを介さずに該当セクションに直接ジャンプします。
  * 目次が空の場合は何も表示されません。
  *
- * @param items - 目次項目の配列。各項目にはid（見出しのID）、text（見出しテキスト）、level（見出しレベル）、items（サブ項目）が含まれます
+ * @param items - 目次項目の配列。各項目にはid（見出しのID）、text（見出しテキスト）、level（見出しレベル）が含まれます
  * @param className - 追加のCSSクラス名（任意）。ボーダーやパディングなどのスタイルをカスタマイズする際に使用します
  * @returns 目次コンポーネント。項目が空の場合はnullを返します
  *
@@ -33,10 +33,6 @@ type TableOfContentsProps = {
  *     id: 'introduction',
  *     text: '概要',
  *     level: 2,
- *     items: [
- *       { id: 'what-is-react', text: 'Reactとは', level: 3 },
- *       { id: 'why-react', text: 'なぜReactを使うのか', level: 3 },
- *     ],
  *   },
  *   {
  *     id: 'installation',
@@ -85,10 +81,10 @@ type TableOfContentsItemProps = {
 /**
  * 目次の個別項目を表示する内部コンポーネント
  *
- * このコンポーネントは目次の1つの項目（見出し）を表示し、サブ項目がある場合は再帰的に表示します。
+ * このコンポーネントは目次の1つの項目（見出し）を表示します。
  * 項目番号を表示し、クリックすると該当セクションにスクロールします。
  *
- * @param item - 表示する目次項目。id、text、levelプロパティと、任意でサブ項目（items）を含みます
+ * @param item - 表示する目次項目。id、text、levelプロパティを含みます
  * @param index - 項目の番号（1から始まる）。目次のナンバリングに使用されます
  * @returns 目次項目コンポーネント
  *
@@ -99,14 +95,10 @@ type TableOfContentsItemProps = {
  *   id: 'introduction',
  *   text: '概要',
  *   level: 2,
- *   items: [
- *     { id: 'what-is-react', text: 'Reactとは', level: 3 },
- *   ],
  * };
  *
  * <TableOfContentsItem item={item} index={1} />
  * // 出力: 1. 概要
- * //       1.1. Reactとは
  * ```
  */
 function TableOfContentsItem({ item, index }: TableOfContentsItemProps) {
@@ -118,23 +110,6 @@ function TableOfContentsItem({ item, index }: TableOfContentsItemProps) {
           {item.text}
         </a>
       </div>
-      {item.items && item.items.length > 0 && (
-        <ol className='mt-2 list-inside space-y-1 pl-6 text-sm'>
-          {item.items.map((child, childIndex) => (
-            <li key={child.id} className='flex items-start'>
-              <span className='mr-2 text-muted-foreground'>
-                {index}.{childIndex + 1}.
-              </span>
-              <a
-                href={`#${child.id}`}
-                className='hover:text-primary hover:underline'
-              >
-                {child.text}
-              </a>
-            </li>
-          ))}
-        </ol>
-      )}
     </li>
   );
 }

--- a/src/lib/toc.ts
+++ b/src/lib/toc.ts
@@ -1,19 +1,16 @@
 import type { TOCItem } from '@/components/feature/content/table-of-contents';
 
 /**
- * MarkdownからH2とH3の見出しを抽出して目次を生成する
+ * MarkdownからH2の見出しを抽出して目次を生成する
  *
  * @param content - Markdownの生のコンテンツ
- * @returns 階層構造を持つ目次項目の配列
+ * @returns 目次項目の配列
  */
 export function extractTOC(content: string): TOCItem[] {
   // 改行でコンテンツを分割
   const lines = content.split('\n');
 
   const result: TOCItem[] = [];
-
-  // 現在処理中のh2要素（親要素）
-  let currentH2: TOCItem | null = null;
 
   // 各行を走査
   for (const line of lines) {
@@ -23,29 +20,10 @@ export function extractTOC(content: string): TOCItem[] {
       // 見出しをIDとして使用
       const id = generateSlug(text);
 
-      currentH2 = {
+      result.push({
         id,
         text,
         level: 2,
-        items: [],
-      };
-
-      result.push(currentH2);
-    }
-    // ### から始まる行はh3要素
-    else if (line.startsWith('### ') && currentH2) {
-      const text = line.replace('### ', '').trim();
-      // 見出しをIDとして使用
-      const id = generateSlug(text);
-
-      if (!currentH2.items) {
-        currentH2.items = [];
-      }
-
-      currentH2.items.push({
-        id,
-        text,
-        level: 3,
       });
     }
   }

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -89,8 +89,18 @@
   @apply mt-12 scroll-m-20 border-b-2 border-border/50 pb-2 text-2xl font-bold tracking-tight first:mt-0;
 }
 
+.markdown-content h2::before {
+  content: "## ";
+  @apply text-muted-foreground/60;
+}
+
 .markdown-content h3:not(.group h3) {
   @apply mt-8 scroll-m-20 text-xl font-semibold tracking-tight;
+}
+
+.markdown-content h3:not(.group h3)::before {
+  content: "### ";
+  @apply text-muted-foreground/60;
 }
 
 .markdown-content h4 {


### PR DESCRIPTION
issue #208の対応として以下の変更を実施：

1. 見出しにマークダウン記号を表示
   - H2見出しの前に「## 」を表示
   - H3見出しの前に「### 」を表示
   - CSS ::before擬似要素を使用して実装

2. 目次の表示をH2までに制限
   - toc.ts: H3抽出ロジックを削除
   - table-of-contents.tsx: H3表示ロジックを削除
   - 目次にはH2のみが表示されるように変更

変更ファイル:
- src/styles/markdown.css
- src/lib/toc.ts
- src/components/feature/content/table-of-contents.tsx