### PR TITLE
fix: Qiita記事のフロントマターにiconとdescriptionを追加

### DIFF
--- a/contents/qiita-blog/2021-12-11_i-want-use-linear-programming-determine.md
+++ b/contents/qiita-blog/2021-12-11_i-want-use-linear-programming-determine.md
@@ -2,9 +2,9 @@
 title: セブンイレブンで最適な食品を線形計画法を用いて決めたい
 slug: i-want-use-linear-programming-determine
 date: 2021-12-11
-description:
-icon:
-icon_url:
+description: 線形計画法を用いてセブンイレブンの食品から栄養バランスと価格を最適化した食事を選択。PuLPライブラリを使用してPFCバランスと価格を考慮した最適解を計算した実験記録。
+icon: 🧮
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Abacus/Flat/abacus_flat.svg
 tags:
   - Python
   - 線形計画法

--- a/contents/qiita-blog/2022-01-27_fall-2021-fundamental-information-technology-engineer.md
+++ b/contents/qiita-blog/2022-01-27_fall-2021-fundamental-information-technology-engineer.md
@@ -2,9 +2,9 @@
 title: 令和3年度秋 基本情報技術者試験 合格体験記
 slug: fall-2021-fundamental-information-technology-engineer
 date: 2022-01-27
-description:
-icon:
-icon_url:
+description: 基本情報技術者試験に合格するまでに使用した参考書やWebサイト、午前免除試験での合格経験をまとめた体験記。
+icon: 🎓
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Graduation%20cap/Flat/graduation_cap_flat.svg
 tags:
   - 資格
   - 基本情報技術者試験

--- a/contents/qiita-blog/2022-11-11_importing-csv-file-into-database.md
+++ b/contents/qiita-blog/2022-11-11_importing-csv-file-into-database.md
@@ -2,9 +2,9 @@
 title: 【MySQL】CSVファイルをDBにインポートする
 slug: importing-csv-file-into-database
 date: 2022-11-11
-description:
-icon:
-icon_url:
+description: MySQLにCSVファイルをインポートする際に躓いた点と解決方法をまとめた備忘録。データベース、テーブル、権限設定について。
+icon: 💾
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Floppy%20disk/Flat/floppy_disk_flat.svg
 tags:
   - MySQL
   - CSV

--- a/contents/qiita-blog/2022-11-12_python-beautifulsoup-did-you-mean-call.md
+++ b/contents/qiita-blog/2022-11-12_python-beautifulsoup-did-you-mean-call.md
@@ -2,9 +2,9 @@
 title: Python BeautifulSoup find()を呼び出すつもりが、find_all()を呼び出してしまったのでしょうか？
 slug: python-beautifulsoup-did-you-mean-call
 date: 2022-11-12
-description:
-icon:
-icon_url:
+description: Pythonでスクレイピングする際に何度も遭遇したfind()とfind_all()の使い分けエラーについての備忘録。
+icon: 🕷️
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Spider%20web/Flat/spider_web_flat.svg
 tags:
   - Python
   - スクレイピング

--- a/contents/qiita-blog/2022-11-23_unable-compile-java.md
+++ b/contents/qiita-blog/2022-11-23_unable-compile-java.md
@@ -2,9 +2,9 @@
 title: Java コンパイルができない
 slug: unable-compile-java
 date: 2022-11-23
-description:
-icon:
-icon_url:
+description: Java学習中にコンパイルができず無駄に時間を浪費した経験からの備忘録。Eclipseを使用したコンパイルエラーの解決方法。
+icon: ☕
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Hot%20beverage/Flat/hot_beverage_flat.svg
 tags:
   - Java
   - Eclipse

--- a/contents/qiita-blog/2022-11-28_pyautogui-image-recognition-magnification-ratio-issue.md
+++ b/contents/qiita-blog/2022-11-28_pyautogui-image-recognition-magnification-ratio-issue.md
@@ -2,9 +2,9 @@
 title: PyAutoGUI 画像認識と拡大比率の問題
 slug: pyautogui-image-recognition-magnification-ratio-issue
 date: 2022-11-28
-description:
-icon:
-icon_url:
+description: PyAutoGUIを用いた作業自動化で発見した画像認識の課題。PCの画面解像度が異なる場合の画像認識の問題について。
+icon: 🔍
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Magnifying%20glass%20tilted%20left/Flat/magnifying_glass_tilted_left_flat.svg
 tags:
   - Python
   - OpenCV

--- a/contents/qiita-blog/2022-12-03_rough-summary-important-parts-readable-code.md
+++ b/contents/qiita-blog/2022-12-03_rough-summary-important-parts-readable-code.md
@@ -2,9 +2,9 @@
 title: リーダブルコードの個人的重要部分をざっくりまとめてみた
 slug: rough-summary-important-parts-readable-code
 date: 2022-12-03
-description:
-icon:
-icon_url:
+description: リーダブルコードの重要な部分をざっくりまとめて、振り返れるようにした備忘録。
+icon: 📖
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Open%20book/Flat/open_book_flat.svg
 tags:
   - リーダブルコード
   - 初心者

--- a/contents/qiita-blog/2022-12-23_fall-2022-applied-information-technology-engineer.md
+++ b/contents/qiita-blog/2022-12-23_fall-2022-applied-information-technology-engineer.md
@@ -2,9 +2,9 @@
 title: 2022年秋 応用情報技術者試験""不""合格体験記
 slug: fall-2022-applied-information-technology-engineer
 date: 2022-12-23
-description:
-icon:
-icon_url:
+description: 応用情報技術者試験の不合格体験をもとに、なぜ不合格だったのかを振り返る雑記。
+icon: 😅
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Grinning%20face%20with%20sweat/Flat/grinning_face_with_sweat_flat.svg
 tags:
   - 雑記
   - 応用情報技術者試験

--- a/contents/qiita-blog/2023-01-22_dont-put-any-more-strain-your.md
+++ b/contents/qiita-blog/2023-01-22_dont-put-any-more-strain-your.md
@@ -2,9 +2,9 @@
 title: 【雑記】これ以上心臓に負荷をかけるな【光で目覚めよう】
 slug: dont-put-any-more-strain-your
 date: 2023-01-22
-description:
-icon:
-icon_url:
+description: アラーム音による心臓への負担を軽減するため、光で目覚める方法を提案する雑記。
+icon: ☀️
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Sun/Flat/sun_flat.svg
 tags:
   - 雑記
   - ライフハック

--- a/contents/qiita-blog/2023-02-06_i-quickly-read-through-book-read.md
+++ b/contents/qiita-blog/2023-02-06_i-quickly-read-through-book-read.md
@@ -2,9 +2,9 @@
 title: 技術書の読書術をざっくり読んで個人的に重要な部分をまとめてみた。
 slug: i-quickly-read-through-book-read
 date: 2023-02-06
-description:
-icon:
-icon_url:
+description: 技術書の読書術の重要な部分をまとめた備忘録。効果的な読書方法とアウトプットについて。
+icon: 📚
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Books/Flat/books_flat.svg
 tags:
   - 本
   - 技術書

--- a/contents/qiita-blog/2023-02-15_django-template-tags-not-recognized-if.md
+++ b/contents/qiita-blog/2023-02-15_django-template-tags-not-recognized-if.md
@@ -2,9 +2,9 @@
 title: Django テンプレートタグに空白を入れると認識してくれません
 slug: django-template-tags-not-recognized-if
 date: 2023-02-15
-description:
-icon:
-icon_url:
+description: Djangoテンプレートタグで空白を入れると認識されない問題についての備忘録。
+icon: 🌐
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Globe%20with%20meridians/Flat/globe_with_meridians_flat.svg
 tags:
   - Python
   - HTML

--- a/contents/qiita-blog/2023-02-19_3-tips-excel-arent-major-useful.md
+++ b/contents/qiita-blog/2023-02-19_3-tips-excel-arent-major-useful.md
@@ -2,9 +2,9 @@
 title: Excel メジャーじゃないけど知っておくと便利な小技3選
 slug: 3-tips-excel-arent-major-useful
 date: 2023-02-19
-description:
-icon:
-icon_url:
+description: 職場でExcelを使う際によく使うショートカットキーやコマンドを紹介。
+icon: 📊
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Bar%20chart/Flat/bar_chart_flat.svg
 tags:
   - Excel
 ---

--- a/contents/qiita-blog/2023-03-27_introduction-pyautogui-automating-routine-tasks.md
+++ b/contents/qiita-blog/2023-03-27_introduction-pyautogui-automating-routine-tasks.md
@@ -2,9 +2,9 @@
 title: 【Python】pyautogui入門 -定型作業を自動化してみる-
 slug: introduction-pyautogui-automating-routine-tasks
 date: 2023-03-27
-description:
-icon:
-icon_url:
+description: PyAutoGUIとOpenCVを使ってメルカリの定型作業を自動化する方法について。
+icon: 🤖
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Robot/Flat/robot_flat.svg
 tags:
   - Python
   - OpenCV

--- a/contents/qiita-blog/2023-04-01_anaconda-seems-different-way-setting-system.md
+++ b/contents/qiita-blog/2023-04-01_anaconda-seems-different-way-setting-system.md
@@ -2,9 +2,9 @@
 title: Anacondaはシステム環境変数の設定方法が異なるらしい
 slug: anaconda-seems-different-way-setting-system
 date: 2023-04-01
-description:
-icon:
-icon_url:
+description: Anacondaとcmdでは環境変数の設定方法が異なるという発見についての備忘録。
+icon: 🐍
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Snake/Flat/snake_flat.svg
 tags:
   - cmd
   - Anaconda

--- a/contents/qiita-blog/2023-04-02_my-first-natural-language-processing-i.md
+++ b/contents/qiita-blog/2023-04-02_my-first-natural-language-processing-i.md
@@ -2,9 +2,9 @@
 title: 【Python】初めての自然言語処理？discord.pyでネガティブな単語に反応するbotを作ってみた。
 slug: my-first-natural-language-processing-i
 date: 2023-04-02
-description:
-icon:
-icon_url:
+description: Pythonとdiscord.pyを使ってネガティブな単語に反応するbotを作成。自然言語処理と形態素解析の入門。
+icon: 🤖
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Robot/Flat/robot_flat.svg
 tags:
   - Python
   - mecab

--- a/contents/qiita-blog/2023-04-23_introduction-pyautogui-trying-remove-highlights-kindle.md
+++ b/contents/qiita-blog/2023-04-23_introduction-pyautogui-trying-remove-highlights-kindle.md
@@ -2,9 +2,9 @@
 title: 【Python】pyautogui入門 -Kindleのハイライトを削除してみる-
 slug: introduction-pyautogui-trying-remove-highlights-kindle
 date: 2023-04-23
-description:
-icon:
-icon_url:
+description: デスクトップのKindleアプリでハイライトと注記を自動削除するPyAutoGUIスクリプト。
+icon: 📱
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Mobile%20phone/Flat/mobile_phone_flat.svg
 tags:
   - Python
   - OpenCV

--- a/contents/qiita-blog/2023-05-02_relisting-items-mercari-shops-so-tedious.md
+++ b/contents/qiita-blog/2023-05-02_relisting-items-mercari-shops-so-tedious.md
@@ -2,9 +2,9 @@
 title: メルカリShopsの再出品があまりにもだるすぎたので効率化してみた
 slug: relisting-items-mercari-shops-so-tedious
 date: 2023-05-02
-description:
-icon:
-icon_url:
+description: メルカリShopsの再出品作業を効率化するため、Pythonとseleniumを使った自動化アプリを開発。
+icon: 🛍️
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Shopping%20bags/Flat/shopping_bags_flat.svg
 tags:
   - Python
   - Selenium

--- a/contents/qiita-blog/2023-05-28_little-late-i-got-summary-book.md
+++ b/contents/qiita-blog/2023-05-28_little-late-i-got-summary-book.md
@@ -2,9 +2,9 @@
 title: 【ChatGPT】今更だけど本を要約してもらった
 slug: little-late-i-got-summary-book
 date: 2023-05-28
-description:
-icon:
-icon_url:
+description: ChatGPTを使って読んだ本を要約してもらった実験記録。
+icon: 🤖
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Robot/Flat/robot_flat.svg
 tags:
   - 睡眠
   - 要約

--- a/contents/qiita-blog/2023-06-10_my-first-frontend-randomly-decide-ramen.md
+++ b/contents/qiita-blog/2023-06-10_my-first-frontend-randomly-decide-ramen.md
@@ -2,9 +2,9 @@
 title: 【React】初めてのフロントエンド〜ランダムで今日行くラーメン二郎を決めてもらう〜
 slug: my-first-frontend-randomly-decide-ramen
 date: 2023-06-10
-description:
-icon:
-icon_url:
+description: Reactを使ってランダムでラーメン二郎の店舗を表示するアプリを作成。初めてのフロントエンド開発。
+icon: 🍜
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Steaming%20bowl/Flat/steaming_bowl_flat.svg
 tags:
   - JavaScript
   - 初心者

--- a/contents/qiita-blog/2023-07-01_lets-integrate-react-flask.md
+++ b/contents/qiita-blog/2023-07-01_lets-integrate-react-flask.md
@@ -2,9 +2,9 @@
 title: React + Flaskを連携させてみる
 slug: lets-integrate-react-flask
 date: 2023-07-01
-description:
-icon:
-icon_url:
+description: ReactとFlaskを連携させたアプリケーション開発の手順。
+icon: ⚛️
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Atom%20symbol/Flat/atom_symbol_flat.svg
 tags:
   - Python
   - Flask

--- a/contents/qiita-blog/2023-07-09_integrating-react-flask-part-2.md
+++ b/contents/qiita-blog/2023-07-09_integrating-react-flask-part-2.md
@@ -2,9 +2,9 @@
 title: ReactとFlaskを連携させてみる part2
 slug: integrating-react-flask-part-2
 date: 2023-07-09
-description:
-icon:
-icon_url:
+description: React→Flask→Reactのデータフロー実装について。FlaskとReactの連携part2。
+icon: ⚛️
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Atom%20symbol/Flat/atom_symbol_flat.svg
 tags:
   - Python
   - Flask

--- a/contents/qiita-blog/2023-08-11_typescript-should-i-use-interface-or.md
+++ b/contents/qiita-blog/2023-08-11_typescript-should-i-use-interface-or.md
@@ -2,9 +2,9 @@
 title: TypeScript interfaceとtypeどっち使うんですか？
 slug: typescript-should-i-use-interface-or
 date: 2023-08-11
-description:
-icon:
-icon_url:
+description: TypeScriptでinterfaceとtypeのどちらを使うべきかについての解説。
+icon: 📘
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Blue%20book/Flat/blue_book_flat.svg
 tags:
   - JavaScript
   - TypeScript

--- a/contents/qiita-blog/2023-08-12_i-tried-see-if-selenium-really.md
+++ b/contents/qiita-blog/2023-08-12_i-tried-see-if-selenium-really.md
@@ -2,9 +2,9 @@
 title: Seleniumが本当にバレバレなのか試してみた
 slug: i-tried-see-if-selenium-really
 date: 2023-08-12
-description:
-icon:
-icon_url:
+description: Seleniumによるスクレイピングが本当にバレるのか実際に検証。
+icon: 🔍
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Magnifying%20glass%20tilted%20left/Flat/magnifying_glass_tilted_left_flat.svg
 tags:
   - Python
   - Selenium

--- a/contents/qiita-blog/2023-08-18_deepen-your-understanding-tight-loose-coupling.md
+++ b/contents/qiita-blog/2023-08-18_deepen-your-understanding-tight-loose-coupling.md
@@ -2,9 +2,9 @@
 title: 密結合と疎結合の理解を深める
 slug: deepen-your-understanding-tight-loose-coupling
 date: 2023-08-18
-description:
-icon:
-icon_url:
+description: 密結合と疎結合の違いと、コードの品質への影響について。
+icon: 🔗
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Link/Flat/link_flat.svg
 tags:
   - TypeScript
   - 疎結合

--- a/contents/qiita-blog/2023-08-20_learn-about-callback-functions-typescript.md
+++ b/contents/qiita-blog/2023-08-20_learn-about-callback-functions-typescript.md
@@ -2,9 +2,9 @@
 title: TypeScriptでコールバック関数を知る
 slug: learn-about-callback-functions-typescript
 date: 2023-08-20
-description:
-icon:
-icon_url:
+description: TypeScriptでコールバック関数について学習した備忘録。
+icon: 🔄
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Counterclockwise%20arrows%20button/Flat/counterclockwise_arrows_button_flat.svg
 tags:
   - TypeScript
   - コールバック

--- a/contents/qiita-blog/2023-08-26_asking-gpt-sensei-good-algorithm-learn.md
+++ b/contents/qiita-blog/2023-08-26_asking-gpt-sensei-good-algorithm-learn.md
@@ -2,9 +2,9 @@
 title: ラーメン二郎のコールで学ぶ良いアルゴリズムとは何かをGPT先生に聞いてみる
 slug: asking-gpt-sensei-good-algorithm-learn
 date: 2023-08-26
-description:
-icon:
-icon_url:
+description: ラーメン二郎のコールシステムを例に、良いアルゴリズムとは何かを学ぶ。
+icon: 🍜
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Steaming%20bowl/Flat/steaming_bowl_flat.svg
 tags:
   - アルゴリズム
   - 初心者

--- a/contents/qiita-blog/2023-08-27_postman-unable-send-request-localhost.md
+++ b/contents/qiita-blog/2023-08-27_postman-unable-send-request-localhost.md
@@ -2,9 +2,9 @@
 title: Postman localhostにリクエストが送信できない
 slug: postman-unable-send-request-localhost
 date: 2023-08-27
-description:
-icon:
-icon_url:
+description: Postmanでlocalhostにリクエストを送信できない問題の解決方法。
+icon: 📮
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Postbox/Flat/postbox_flat.svg
 tags:
   - API
   - Postman

--- a/contents/qiita-blog/2023-09-18_angular-practice-i-made-population-graph.md
+++ b/contents/qiita-blog/2023-09-18_angular-practice-i-made-population-graph.md
@@ -2,9 +2,9 @@
 title: Angularの練習ということで船橋市の人口推移グラフを作ってみた
 slug: angular-practice-i-made-population-graph
 date: 2023-09-18
-description:
-icon:
-icon_url:
+description: Angularの練習として船橋市の人口推移グラフを作成。
+icon: 📈
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Chart%20increasing/Flat/chart_increasing_flat.svg
 tags:
   - TypeScript
   - Angular

--- a/contents/qiita-blog/2023-10-09_i-want-make-booknotion-even-better.md
+++ b/contents/qiita-blog/2023-10-09_i-want-make-booknotion-even-better.md
@@ -2,9 +2,9 @@
 title: BookNotionを更に神アプリにしたい その１
 slug: i-want-make-booknotion-even-better
 date: 2023-10-09
-description:
-icon:
-icon_url:
+description: BookNotionをより便利にするための機能拡張について。
+icon: 📔
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Notebook%20with%20decorative%20cover/Flat/notebook_with_decorative_cover_flat.svg
 tags:
   - JavaScript
   - Notion

--- a/contents/qiita-blog/2023-10-14_i-created-my-own-booknotion.md
+++ b/contents/qiita-blog/2023-10-14_i-created-my-own-booknotion.md
@@ -2,9 +2,9 @@
 title: 自分だけのBookNotionを爆誕させた
 slug: i-created-my-own-booknotion
 date: 2023-10-14
-description:
-icon:
-icon_url:
+description: KindleのハイライトをNotionにまとめる自分専用BookNotionアプリを開発。
+icon: 📔
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Notebook%20with%20decorative%20cover/Flat/notebook_with_decorative_cover_flat.svg
 tags:
   - Next.js
   - Notion

--- a/contents/qiita-blog/2023-10-29_list-songs-you-havent-heard-minase.md
+++ b/contents/qiita-blog/2023-10-29_list-songs-you-havent-heard-minase.md
@@ -2,9 +2,9 @@
 title: 【個人開発】水瀬いのりさんのライブで聴いたことのない曲を一覧表示するぞ
 slug: list-songs-you-havent-heard-minase
 date: 2023-10-29
-description:
-icon:
-icon_url:
+description: 水瀬いのりさんのライブで聴いたことのない曲を一覧表示するアプリの開発。
+icon: 🎵
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Musical%20note/Flat/musical_note_flat.svg
 tags:
   - 個人開発
   - Next.js

--- a/contents/qiita-blog/2023-12-23_i-made-pokemon-generator-10%-chance.md
+++ b/contents/qiita-blog/2023-12-23_i-made-pokemon-generator-10%-chance.md
@@ -2,9 +2,9 @@
 title: １０％の確率でドオーしか表示されないポケモン生成サイトを作った
 slug: i-made-pokemon-generator-10%-chance
 date: 2023-12-23
-description:
-icon:
-icon_url:
+description: PokeAPIを使って10%の確率でドオーしか表示されないポケモン生成サイトを作成。
+icon: 🎮
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Video%20game/Flat/video_game_flat.svg
 tags:
   - 個人開発
   - ポケモン

--- a/contents/qiita-blog/2023-12-29_creating-dark-pattern-shadcn-ui.md
+++ b/contents/qiita-blog/2023-12-29_creating-dark-pattern-shadcn-ui.md
@@ -2,9 +2,9 @@
 title: ザ・ダークパターンをshadcn/uiで作成する
 slug: creating-dark-pattern-shadcn-ui
 date: 2023-12-29
-description:
-icon:
-icon_url:
+description: shadcn/uiを使ってダークパターンを実装する例。
+icon: 🌑
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/New%20moon/Flat/new_moon_flat.svg
 tags:
   - UI
   - Design

--- a/contents/qiita-blog/2024-01-03_nextjs13-dynamically-change-api-path-during.md
+++ b/contents/qiita-blog/2024-01-03_nextjs13-dynamically-change-api-path-during.md
@@ -2,9 +2,9 @@
 title: Next.js13 デプロイ時にAPIのパスを動的に変えるやり方
 slug: nextjs13-dynamically-change-api-path-during
 date: 2024-01-03
-description:
-icon:
-icon_url:
+description: Next.js13でデプロイ時にAPIのパスを動的に変更する方法。
+icon: 🔗
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Link/Flat/link_flat.svg
 tags:
   - API
   - Next.js

--- a/contents/qiita-blog/2024-01-07_app-generates-incoherent-sentences.md
+++ b/contents/qiita-blog/2024-01-07_app-generates-incoherent-sentences.md
@@ -2,9 +2,9 @@
 title: 支離滅裂な文章を生成するアプリ
 slug: app-generates-incoherent-sentences
 date: 2024-01-07
-description:
-icon:
-icon_url:
+description: GASのLanguageAppクラスを使って支離滅裂な文章を生成するアプリ。
+icon: 🎭
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Performing%20arts/Flat/performing_arts_flat.svg
 tags:
   - GAS
   - Next.js

--- a/contents/qiita-blog/2024-01-21_setting-id-uuid-careful-type-definition.md
+++ b/contents/qiita-blog/2024-01-21_setting-id-uuid-careful-type-definition.md
@@ -2,9 +2,9 @@
 title: 【FastAPI】idをuuidで設定するときは型定義に気をつけたい
 slug: setting-id-uuid-careful-type-definition
 date: 2024-01-21
-description:
-icon:
-icon_url:
+description: FastAPIでidをuuidで設定する際の型定義の注意点。
+icon: 🆔
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/ID%20button/Flat/id_button_flat.svg
 tags:
   - Python
   - FastAPI

--- a/contents/qiita-blog/2024-02-23_i-almost-got-stuck-without-setting.md
+++ b/contents/qiita-blog/2024-02-23_i-almost-got-stuck-without-setting.md
@@ -2,9 +2,9 @@
 title: Google Places API (New)で言語コードを設定せず沼りかけた
 slug: i-almost-got-stuck-without-setting
 date: 2024-02-23
-description:
-icon:
-icon_url:
+description: Google Places API (New)で言語コードを設定せず沼りかけた経験。
+icon: 🗺️
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/World%20map/Flat/world_map_flat.svg
 tags:
   - GoogleMapsAPI
   - GoogleCloud

--- a/contents/qiita-blog/2024-03-17_i-did-i-got-runtimeerror-event.md
+++ b/contents/qiita-blog/2024-03-17_i-did-i-got-runtimeerror-event.md
@@ -2,9 +2,9 @@
 title: SQLAlchemy + pytestでRuntimeError: Event loop is closedが起きたときにやったこと
 slug: i-did-i-got-runtimeerror-event
 date: 2024-03-17
-description:
-icon:
-icon_url:
+description: SQLAlchemyとpytestでRuntimeError: Event loop is closedエラーが発生した際の対処法。
+icon: 🐛
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Bug/Flat/bug_flat.svg
 tags:
   - MySQL
   - sqlalchemy

--- a/contents/qiita-blog/2024-04-08_try-using-real-estate-information-library.md
+++ b/contents/qiita-blog/2024-04-08_try-using-real-estate-information-library.md
@@ -2,9 +2,9 @@
 title: 不動産情報ライブラリAPIを使ってみる！
 slug: try-using-real-estate-information-library
 date: 2024-04-08
-description:
-icon:
-icon_url:
+description: 国土交通省の不動産情報ライブラリAPIを使ってみた体験記。
+icon: 🏠
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/House/Flat/house_flat.svg
 tags:
   - Python
   - API

--- a/contents/qiita-blog/2024-04-27_create-line-bot-randomly-displays-convenience.md
+++ b/contents/qiita-blog/2024-04-27_create-line-bot-randomly-displays-convenience.md
@@ -2,9 +2,9 @@
 title: コンビニスイーツをランダムに表示するLINE BOTをつくる
 slug: create-line-bot-randomly-displays-convenience
 date: 2024-04-27
-description:
-icon:
-icon_url:
+description: CloudflareWorkersとHonoを使ってコンビニスイーツをランダムに表示するLINE BOTを作成。
+icon: 🍰
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Shortcake/Flat/shortcake_flat.svg
 tags:
   - LINEmessagingAPI
   - CloudflareWorkers

--- a/contents/qiita-blog/2025-01-03_2025-all-you-need-do-make.md
+++ b/contents/qiita-blog/2025-01-03_2025-all-you-need-do-make.md
@@ -2,9 +2,9 @@
 title: 2025年は毎日ベッドメイキングだけやればいい。
 slug: 2025-all-you-need-do-make
 date: 2025-01-03
-description:
-icon:
-icon_url:
+description: ベッドメイキングから始まる小さな成功体験の重要性についてのポエム。
+icon: 🛏️
+icon_url: https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Bed/Flat/bed_flat.svg
 tags:
   - ポエム
 ---


### PR DESCRIPTION
全42件のQiita記事のフロントマターに以下の項目を追加:
- description: 記事の要約
- icon: 記事内容に適した絵文字
- icon_url: FluentUI Emojiの対応するSVG URL

これにより、contents/blogディレクトリへの移行時にYAML解析エラーを防ぐ。

Closes #240