### PR TITLE
fix: Mermaidダークモード時の文字色と線を白に修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,7 +333,7 @@ relative_path: 'src/auth/user.ts'
 
 ```bash
 # 型チェック
-bun run type-check
+bun run typecheck
 
 # Lint
 bun run lint

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -149,6 +149,22 @@
   @apply h-auto w-full;
 }
 
+/* Mermaid ダークモード対応: 文字色と矢印・線を白に上書き */
+.dark .markdown-content .mermaid svg text {
+  fill: white !important;
+}
+
+.dark .markdown-content .mermaid svg .edgePath path,
+.dark .markdown-content .mermaid svg .edgePath marker path,
+.dark .markdown-content .mermaid svg line[class*="messageLine"],
+.dark .markdown-content .mermaid svg path[class*="messageLine"] {
+  stroke: white !important;
+}
+
+.dark .markdown-content .mermaid svg marker path {
+  fill: white !important;
+}
+
 .markdown-content hr {
   @apply my-8 border-border/50;
 }


### PR DESCRIPTION
ダークモード時にMermaidダイアグラムの文字と線が背景と同化する問題を修正。
- テキスト要素のfillを白に設定
- messageLine、edgePath、markerの線色を白に設定