### PR TITLE
fix: Aboutページのアバター画像プリロード警告を解消

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -33,6 +33,11 @@ const nextConfig = {
         hostname: 'pub-151065dba8464e6982571edb9ce95445.r2.dev',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'avatars.githubusercontent.com',
+        pathname: '/**',
+      },
     ],
   },
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -10,6 +10,7 @@ import {
   Twitter,
 } from 'lucide-react';
 import type { Metadata } from 'next';
+import Image from 'next/image';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -148,11 +149,13 @@ export default function AboutPage() {
           <div className='relative'>
             <div className='absolute inset-0 animate-pulse rounded-full bg-primary/20 blur-[50px]' />
             <div className='relative h-40 w-40 overflow-hidden rounded-full border-4 border-background bg-muted shadow-xl md:h-48 md:w-48'>
-              {/* biome-ignore lint/performance/noImgElement: Avatar image */}
-              <img
+              <Image
                 src='https://avatars.githubusercontent.com/u/116779921?v=4'
                 alt='sui avatar'
+                width={192}
+                height={192}
                 className='h-full w-full object-cover transition-transform duration-500 hover:scale-110'
+                priority
               />
             </div>
           </div>


### PR DESCRIPTION
## 概要

Aboutページのブラウザコンソールで発生していた、GitHubアバター画像のプリロード警告を解消しました。

## 警告内容

```
The resource https://avatars.githubusercontent.com/u/116779921?v=4 was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally.
```

## 原因

`about/page.tsx`で通常の`<img>`タグを使用してGitHubアバター画像を表示していたため、Next.jsが自動的に画像をプリロードしましたが、適切な`as`属性が設定されていませんでした。

## 対応内容

### src/app/about/page.tsx
- 通常の`<img>`タグから`next/image`の`Image`コンポーネントに変更
- `width={192}`、`height={192}`を明示的に指定
- `priority`プロップを追加して、Above-the-fold画像として優先的にロード

### next.config.mjs
- `remotePatterns`に`avatars.githubusercontent.com`ドメインを追加
- 外部画像の使用を許可

## 結果

Next.jsの`Image`コンポーネントを使用することで、適切なプリロード設定と`as="image"`属性が自動的に設定されるようになり、ブラウザコンソールの警告が解消されます。

## チェックリスト

- [x] 型チェック通過
- [x] Lint通過
- [x] コード変更が意図通り