### PR TITLE
fix: Content-Typeヘッダーのcharsetが削除される問題を修正

### DIFF
--- a/src/pages/blog/[slug].md.ts
+++ b/src/pages/blog/[slug].md.ts
@@ -26,10 +26,12 @@ export async function GET({ params }: APIContext) {
   ${post.body}
     `;
 
+  const headers = new Headers({
+    'Content-Type': 'text/markdown; charset=utf-8',
+  });
+
   return new Response(body, {
     status: 200,
-    headers: {
-      'Content-Type': 'text/markdown; charset=utf-8',
-    },
+    headers,
   });
 }

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -33,10 +33,12 @@ export async function GET() {
   const posts = await getAllBlogPosts();
   const markdownContent = renderLlmsTxt(posts);
 
+  const headers = new Headers({
+    'Content-Type': 'text/plain; charset=utf-8',
+  });
+
   return new Response(markdownContent, {
     status: 200,
-    headers: {
-      'Content-Type': 'text/plain; charset=utf-8',
-    },
+    headers,
   });
 }


### PR DESCRIPTION
## 概要
AstroのAPIエンドポイントでContent-Typeヘッダーのcharsetパラメータが削除され、ブラウザでMarkdownファイルが文字化けする問題を修正しました。

## 問題の詳細
- ブラウザで `/blog/[slug].md` にアクセスすると日本語が文字化けしていた
- curlでは正常に表示されるが、ブラウザではUTF-8として認識されない
- ローカル環境でも本番環境でも同じ現象が発生

## 原因
Astroの既知の問題([withastro/astro#3573](https://github.com/withastro/astro/issues/3573))により、オブジェクトリテラルでヘッダーを指定すると、`charset=utf-8`パラメータが削除される場合があります。

## 変更内容
- `src/pages/blog/[slug].md.ts`: `new Headers()`を使用してcharsetを保持
- `src/pages/llms.txt.ts`: `new Headers()`を使用してcharsetを保持

## 技術的詳細
以前:
```typescript
return new Response(body, {
  status: 200,
  headers: {
    'Content-Type': 'text/markdown; charset=utf-8',
  },
});
```

修正後:
```typescript
const headers = new Headers({
  'Content-Type': 'text/markdown; charset=utf-8',
});

return new Response(body, {
  status: 200,
  headers,
});
```

## テスト方法
1. ローカルで開発サーバーを起動
2. ブラウザで `http://localhost:4321/blog/automate-dependency-updates-with-renovate.md` にアクセス
3. 日本語が正しく表示されることを確認
4. デベロッパーツールでContent-Typeヘッダーに `charset=utf-8` が含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)