### PR TITLE
fix: peter-evans/create-pull-requestを使用してgit認証問題を解決

### DIFF
--- a/.github/workflows/create-short.yml
+++ b/.github/workflows/create-short.yml
@@ -81,59 +81,52 @@ jobs:
           cat "contents/shorts/${UUID}.md"
 
       - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
         env:
-          GH_TOKEN: ${{ github.token }}
           UUID: ${{ steps.meta.outputs.uuid }}
           TITLE: ${{ steps.issue.outputs.title }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_USER: ${{ github.event.issue.user.login }}
-        run: |
-          # Git設定
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+        with:
+          token: ${{ github.token }}
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          commit-message: |
+            Add short: ${{ steps.issue.outputs.title }}
 
-          # ブランチ作成
-          BRANCH="short/${UUID}"
-          git checkout -b "$BRANCH"
+            Issue: #${{ github.event.issue.number }}
+            UUID: ${{ steps.meta.outputs.uuid }}
+          branch: short/${{ steps.meta.outputs.uuid }}
+          delete-branch: true
+          title: "📝 Short: ${{ steps.issue.outputs.title }}"
+          body: |
+            ## Summary
 
-          # コミット
-          git add "contents/shorts/${UUID}.md"
-          git commit -m "Add short: ${TITLE}
+            新しいShortを追加します。
 
-          Issue: #${ISSUE_NUMBER}
-          UUID: ${UUID}"
+            ## Details
 
-          # プッシュ
-          git push origin "$BRANCH"
+            - **Issue**: #${{ github.event.issue.number }}
+            - **UUID**: `${{ steps.meta.outputs.uuid }}`
+            - **File**: `contents/shorts/${{ steps.meta.outputs.uuid }}.md`
 
-          # PR作成
-          gh pr create \
-            --title "📝 Short: ${TITLE}" \
-            --body "## Summary
+            ---
 
-          新しいShortを追加します。
-
-          ## Details
-
-          - **Issue**: #${ISSUE_NUMBER}
-          - **UUID**: \`${UUID}\`
-          - **File**: \`contents/shorts/${UUID}.md\`
-
-          ---
-
-          🤖 This PR was automatically created by GitHub Actions." \
-            --label "short" \
-            --assignee "${ISSUE_USER}"
+            🤖 This PR was automatically created by GitHub Actions.
+          labels: short
+          assignees: ${{ github.event.issue.user.login }}
 
       - name: Close Issue
-        if: success()
+        if: steps.cpr.outputs.pull-request-operation == 'created'
         env:
           GH_TOKEN: ${{ github.token }}
           UUID: ${{ steps.meta.outputs.uuid }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
         run: |
           gh issue close "${ISSUE_NUMBER}" --comment "✅ Shortファイルを作成し、PRを作成しました。
 
+          - **PR**: ${PR_URL}
           - **File**: \`contents/shorts/${UUID}.md\`
           - **Branch**: \`short/${UUID}\`
 


### PR DESCRIPTION
persist-credentials: falseでもPR作成できるように修正。

## 変更内容
- 手動git操作からpeter-evans/create-pull-requestアクションに変更
- 認証エラー(exit code 128)を解決
- PR URLをIssueコメントに含めるように改善

🤖 Generated with [Claude Code](https://claude.com/claude-code)