### PR TITLE
fix: GitHub App Tokenを使用してCI実行とIssue自動クローズを実現

### DIFF
--- a/.github/workflows/create-short.yml
+++ b/.github/workflows/create-short.yml
@@ -23,6 +23,17 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+
       - name: Generate UUID and Date
         id: meta
         run: |
@@ -88,7 +99,7 @@ jobs:
           TITLE: ${{ steps.issue.outputs.title }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         with:
-          token: ${{ github.token }}
+          token: ${{ steps.generate-token.outputs.token }}
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           commit-message: |
@@ -106,28 +117,13 @@ jobs:
 
             ## Details
 
-            - **Issue**: #${{ github.event.issue.number }}
             - **UUID**: `${{ steps.meta.outputs.uuid }}`
             - **File**: `contents/shorts/${{ steps.meta.outputs.uuid }}.md`
+
+            Closes #${{ github.event.issue.number }}
 
             ---
 
             🤖 This PR was automatically created by GitHub Actions.
           labels: short
           assignees: ${{ github.event.issue.user.login }}
-
-      - name: Close Issue
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          UUID: ${{ steps.meta.outputs.uuid }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
-        run: |
-          gh issue close "${ISSUE_NUMBER}" --comment "✅ Shortファイルを作成し、PRを作成しました。
-
-          - **PR**: ${PR_URL}
-          - **File**: \`contents/shorts/${UUID}.md\`
-          - **Branch**: \`short/${UUID}\`
-
-          PRをマージすると、自動的にデプロイされます。"


### PR DESCRIPTION
## 概要

Shorts自動生成ワークフローでGitHub App Tokenを使用し、CI実行とIssue自動クローズを実現します。

## 問題

PR #365でマージされたワークフローには以下の問題がありました：

1. `GITHUB_TOKEN`ではPR作成権限エラーが発生
2. CI/CDが実行されない
3. プレビューデプロイが見えない

## 変更内容

### GitHub App Token使用

- `actions/create-github-app-token`でトークン生成
- `peter-evans/create-pull-request`でトークンを使用
- CI/CDが正常に実行されるように

### Issue自動クローズ

- PR本文に`Closes #<issue-number>`を追加
- PRマージ時に自動でIssueがクローズされる
- Development linkingが正常に機能

### 削除した機能

- 手動Issue自動クローズステップを削除（不要）

## 検証

- actionlint ✅
- ghalint ✅
- zizmor ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)