### PR TITLE
fix: Issueタイトルを使用しShortsワークフローを改善

### DIFF
--- a/.github/ISSUE_TEMPLATE/short.yml
+++ b/.github/ISSUE_TEMPLATE/short.yml
@@ -1,6 +1,7 @@
 name: Short投稿
 description: 技術的な知見をShortsとして投稿
 labels: ["short"]
+title: "[Short] "
 body:
   - type: markdown
     attributes:
@@ -8,16 +9,9 @@ body:
         ## Shorts投稿
 
         ブログ記事にするには軽すぎるが、共有しておきたい技術的な知見を投稿します。
-        このIssueを作成すると、自動的にMarkdownファイルが生成されPRが作成されます。
 
-  - type: input
-    id: title
-    attributes:
-      label: タイトル
-      description: Shortのタイトルを入力してください
-      placeholder: "例: AstroでResponseヘッダーを指定する際の注意点"
-    validations:
-      required: true
+        **Issueタイトル**がそのままShortsのタイトルになります。
+        このIssueを作成すると、自動的にMarkdownファイルが生成されPRが作成されます。
 
   - type: textarea
     id: content

--- a/.github/workflows/create-short.yml
+++ b/.github/workflows/create-short.yml
@@ -32,7 +32,6 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           permission-contents: write
           permission-pull-requests: write
-          permission-issues: write
 
       - name: Generate UUID and Date
         id: meta
@@ -54,14 +53,16 @@ jobs:
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
-          # Issue本文からタイトルと本文を抽出
-          # 本文を抽出（### 本文セクション以降を取得）
-          CONTENT=$(echo "$ISSUE_BODY" | sed -n '/### 本文/,$ p' | tail -n +3)
+          # タイトルはIssueタイトルから"[Short] "を除去
+          TITLE="${ISSUE_TITLE#\[Short\] }"
+
+          # 本文を抽出（### 本文 セクション以降、確認事項の前まで）
+          CONTENT=$(echo "$ISSUE_BODY" | sed -n "/### 本文/,/^### 確認事項/ {/### 本文/d; /^### 確認事項/d; p}" | sed "s/^\`\`\`markdown\$//; s/^\`\`\`\$//" | sed "/^$/d" | sed "1{/^$/d}")
 
           # マルチライン対応
           {
             echo "title<<EOF"
-            echo "$ISSUE_TITLE"
+            echo "$TITLE"
             echo "EOF"
             echo "content<<EOF"
             echo "$CONTENT"


### PR DESCRIPTION
## 概要

Issueタイトル=Shortsタイトルにし、重複入力を削減。本文抽出ロジックとGitHub App権限も修正しました。

## 変更内容

### Issueテンプレート (`.github/ISSUE_TEMPLATE/short.yml`)

- ❌ タイトル入力欄を削除
- ✅ IssueタイトルがそのままShortsタイトルに
- ✅ デフォルトプレフィックス `[Short] ` を追加

**Before:**
```
### タイトル
(ユーザー入力)

### 本文
(ユーザー入力)
```

**After:**
```
Issueタイトル: [Short] (ユーザー入力)

### 本文
(ユーザー入力)
```

### ワークフロー (`.github/workflows/create-short.yml`)

1. **タイトル抽出ロジック変更**
   - Issueタイトルから `[Short] ` プレフィックスを除去
   - シェル組み込み機能 `${var#pattern}` を使用

2. **本文抽出ロジック修正**
   - 確認事項セクションを除外
   - markdownコードブロックを正しく除去

3. **GitHub App権限の最適化**
   - `permission-contents: write` ✅
   - `permission-pull-requests: write` ✅
   - ~~`permission-issues: write`~~ ❌ 削除（不要）

## 解決した問題

- ✅ タイトル重複入力の手間を削減
- ✅ 本文に確認事項が含まれる問題を修正
- ✅ 本文のmarkdownコードブロックが残る問題を修正
- ✅ 不要な権限要求によるエラーを解消

## 検証

- actionlint ✅
- ghalint ✅
- zizmor ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)