### PR TITLE
feat: プレビューURL生成の自動化とWrangler Versionsへの移行

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,9 +60,20 @@ jobs:
       - name: Deploy to Cloudflare Workers (Preview)
         id: deploy
         run: |
-          DEPLOY_OUTPUT=$(bunx wrangler deploy --env preview 2>&1)
+          # Use wrangler versions upload with a stable alias for the PR
+          # This generates a URL like: https://pr-<number>-<worker-name>.<subdomain>.workers.dev
+          DEPLOY_OUTPUT=$(bunx wrangler versions upload --preview-alias "pr-${{ github.event.pull_request.number }}" 2>&1)
           echo "$DEPLOY_OUTPUT"
-          PREVIEW_URL=$(echo "$DEPLOY_OUTPUT" | grep -oP 'https://[^\s]+\.workers\.dev' | head -n 1)
+
+          # Extract the Version Preview URL
+          # Output format usually contains: "Worker Version Preview URL: https://..."
+          PREVIEW_URL=$(echo "$DEPLOY_OUTPUT" | grep -oP 'https://[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+\.workers\.dev' | head -n 1)
+
+          if [ -z "$PREVIEW_URL" ]; then
+            echo "::error::Could not extract preview URL from deployment output"
+            exit 1
+          fi
+
           echo "preview_url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -77,7 +88,7 @@ jobs:
 
           **Preview URL**: ${PREVIEW_URL}
 
-          Note: Access the worker via your configured routes or custom domain."
+          Note: This is an ephemeral version. Access the worker via the link above."
         env:
           GH_TOKEN: ${{ github.token }}
           PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,12 +9,4 @@
   "vars": {
     "PUBLIC_APP_URL": "https://suntory-n-water.com"
   },
-  "env": {
-    "preview": {
-      "name": "sui-tech-blog-preview",
-      "vars": {
-        "PUBLIC_APP_URL": "https://suntory-n-water.com"
-      }
-    }
-  }
 }


### PR DESCRIPTION
## 概要
Cloudflare WorkersのVersions機能を活用し、PRごとに動的かつ一意なプレビューURLを自動生成するようにデプロイフローを刷新しました。

## 変更内容
- `wrangler.jsonc` からハードコードされた `preview` 環境設定を削除
- `deploy.yml` のデプロイコマンドを `wrangler versions upload` に変更
- PR番号に基づくエイリアス（`pr-<number>`）の付与とURL抽出ロジックの追加

## テスト
- [x] ローカルでの静的解析 (`pinact`, `actionlint`, `ghalint`, `zizmor`) パス確認
- [x] PR作成後のGitHub Actions動作確認（プレビューURLがコメントされること）