### PR TITLE
fix: renovate auto-mergeをsquashからmergeに変更

### DIFF
--- a/.github/workflows/renovate-auto-merge.yml
+++ b/.github/workflows/renovate-auto-merge.yml
@@ -31,4 +31,4 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh pr merge --repo "$GITHUB_REPOSITORY" --squash --auto --delete-branch "$PR_NUMBER"
+        run: gh pr merge --repo "$GITHUB_REPOSITORY" --merge --auto --delete-branch "$PR_NUMBER"


### PR DESCRIPTION
## 概要

Renovate PRのauto-mergeが失敗していた問題を修正します。

## 問題

PR #403 でauto-mergeワークフローが以下のエラーで失敗:

```
GraphQL: Squash merges are not allowed on this repository. (mergePullRequest)
```

## 原因

- ワークフローでは `--squash` オプションを使用
- リポジトリ設定では squash merge が無効化されている
- 有効なのは merge commit と rebase merge のみ

## 変更内容

`.github/workflows/renovate-auto-merge.yml`:
- `--squash` → `--merge` に変更
- マージコミットメッセージは `Merge pull request #XXX from ...` 形式になる

## 確認方法

リポジトリのマージ設定:
```json
{
  "allow_merge_commit": true,
  "allow_rebase_merge": true,
  "allow_squash_merge": false
}
```

## 影響範囲

- Renovate PRのauto-mergeが正常に動作するようになる
- マージ方法がmerge commitになる（従来の `Merge pull request #XXX` メッセージ）

## 関連

- 問題が発生していたPR: #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)