### PR TITLE
style: フォント・アラート・h2のUI改善

### DIFF
--- a/src/components/feature/content/blog-card.astro
+++ b/src/components/feature/content/blog-card.astro
@@ -113,7 +113,7 @@ const displayUrl =
 
     {
       metadata.description && (
-        <p class='mb-4 flex-1 text-sm leading-relaxed text-muted-foreground line-clamp-2 md:line-clamp-4'>
+        <p class='mb-4 flex-1 text-sm leading-relaxed text-muted-foreground line-clamp-4'>
           {metadata.description}
         </p>
       )

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -112,6 +112,13 @@ const jsonLdWebsite = {
     <meta name='twitter:description' content={description} />
     <meta name='twitter:image' content={ogImage} />
 
+    <link rel='preconnect' href='https://fonts.googleapis.com' />
+    <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin />
+    <link
+      rel='stylesheet'
+      href='https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&display=swap'
+    />
+
     <link rel='canonical' href={finalCanonicalUrl} />
     <link
       rel='alternate'

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -30,7 +30,7 @@
   --color-popover-foreground: var(--popover-foreground);
 
   /* フォントファミリー */
-  --font-sans: "noto-sans", sans-serif;
+  --font-sans: "Noto Sans JP", sans-serif;
   --font-mono: 'PlemolJP35Console', monospace;
 
   /* コンテナ設定(v4ではCSS変数として定義) */
@@ -130,7 +130,7 @@
     @apply text-3xl md:text-4xl;
   }
   h2 {
-    @apply mb-4 border-b text-2xl md:text-3xl;
+    @apply mb-4 border-b pb-2 text-2xl md:text-3xl;
   }
   p,
   li {

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -249,15 +249,15 @@
 }
 
 .markdown-content .markdown-alert-note {
-  @apply border-slate-200 bg-slate-50/50 dark:border-slate-800 dark:bg-slate-900/30;
+  @apply border-blue-400 bg-blue-100 dark:border-blue-700 dark:bg-blue-950/40;
 }
 
 .markdown-content .markdown-alert-note > .markdown-alert-title {
-  @apply text-slate-800 dark:text-slate-300;
+  @apply text-blue-800 dark:text-blue-300;
 }
 
 .markdown-content .markdown-alert-tip {
-  @apply border-green-200 bg-green-50/50 dark:border-green-900 dark:bg-green-950/30;
+  @apply border-green-400 bg-green-100 dark:border-green-800 dark:bg-green-950/40;
 }
 
 .markdown-content .markdown-alert-tip > .markdown-alert-title {
@@ -265,7 +265,7 @@
 }
 
 .markdown-content .markdown-alert-important {
-  @apply border-purple-200 bg-purple-50/50 dark:border-purple-900 dark:bg-purple-950/30;
+  @apply border-purple-400 bg-purple-100 dark:border-purple-800 dark:bg-purple-950/40;
 }
 
 .markdown-content .markdown-alert-important > .markdown-alert-title {
@@ -273,7 +273,7 @@
 }
 
 .markdown-content .markdown-alert-warning {
-  @apply border-amber-200 bg-amber-50/50 dark:border-amber-900 dark:bg-amber-950/30;
+  @apply border-amber-400 bg-amber-100 dark:border-amber-800 dark:bg-amber-950/40;
 }
 
 .markdown-content .markdown-alert-warning > .markdown-alert-title {
@@ -281,7 +281,7 @@
 }
 
 .markdown-content .markdown-alert-caution {
-  @apply border-red-200 bg-red-50/50 dark:border-red-900 dark:bg-red-950/30;
+  @apply border-red-400 bg-red-100 dark:border-red-800 dark:bg-red-950/40;
 }
 
 .markdown-content .markdown-alert-caution > .markdown-alert-title {


### PR DESCRIPTION
## Summary

- フォントを Adobe Fonts `noto-sans` から Google Fonts **Noto Sans JP** に切り替え
- GFM Alerts（`[!NOTE]` 等）のライト/ダークモード両方の視認性を改善（透明度なしのソリッドカラーに統一）
- h2 の `border-bottom` とテキストの間隔に `pb-2` を追加
- blog-card の description を `line-clamp-4` に統一

## Test plan

- [ ] ライトモード・ダークモードで各アラート（NOTE/TIP/IMPORTANT/WARNING/CAUTION）の視認性確認
- [ ] h2 の border 間隔確認
- [ ] フォントが正しく読み込まれること確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)