### PR TITLE
fix: <details>ブロックを読了時間の計算から除外する

### DIFF
--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -71,6 +71,7 @@ export async function getBlogPostBySlug(slug: string) {
 export function calculateReadingTime(body: string | undefined): number {
   const CHARS_PER_MINUTE_JA = 650;
   const readableText = (body ?? '')
+    .replace(/<details>[\s\S]*?<\/details>/g, '')
     .replace(/```[\s\S]*?```/g, '')
     .replace(/`[^`]+`/g, '')
     .replace(/\[([^\]]*)\]\([^)]+\)/g, '$1')


### PR DESCRIPTION
## Summary

- `calculateReadingTime` で `<details>` ブロック内のコンテンツが読了時間にカウントされていた問題を修正
- コードブロック除去の前に `<details>[\s\S]*?<\/details>` をまるごと除去するよう1行追加
- 原因: `<details>` 内の bash コードブロックに入れ子の ` ```js ` が含まれており、正規表現 `/```[\s\S]*?```/g` が非貪欲マッチのため正しくストリップできていなかった

**修正前後の読了時間 (agent-browser-vs-playwright-cli-revisit.md)**

| | 文字数 | 読了時間 |
|---|---|---|
| 修正前 | 5,545 chars | 9分 |
| 修正後 | 3,381 chars | 5分 |

## Test plan

- [ ] CI (lint / type-check) が通ること
- [ ] 対象記事の読了時間が 9分 → 5分 になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)