### PR TITLE
perf: PlemolJP35Consoleフォント削除・ClientRouter削除

### DIFF
--- a/src/components/feature/content/blog-card.astro
+++ b/src/components/feature/content/blog-card.astro
@@ -10,16 +10,9 @@ type Props = {
   priority?: boolean;
   inlineSvg?: string;
   readingTime?: number;
-  transitionPrefix?: string;
 };
 
-const {
-  data,
-  priority,
-  inlineSvg,
-  readingTime,
-  transitionPrefix = 'blog',
-} = Astro.props;
+const { data, priority, inlineSvg, readingTime } = Astro.props;
 
 /**
  * ブログ記事のカードを表示するコンポーネント
@@ -53,7 +46,6 @@ const displayUrl =
     </div>
     <div
       class='absolute inset-0 flex items-center justify-center transition-transform duration-500 group-hover:scale-110'
-      transition:name={`${transitionPrefix}-icon-${slug}`}
     >
       {
         inlineSvg ? (
@@ -80,7 +72,6 @@ const displayUrl =
     </div>
     <div
       class='absolute bottom-3 left-3 flex items-center gap-2 rounded bg-background/90 px-2 py-0.5 font-mono text-xs text-muted-foreground backdrop-blur'
-      transition:name={`${transitionPrefix}-date-${slug}`}
     >
       <time datetime={dateISO}>{formattedDate}</time>
       {readingTime && <span>{readingTime}分</span>}
@@ -106,7 +97,6 @@ const displayUrl =
 
     <h2
       class='mb-3 text-base font-bold transition-colors group-hover:text-primary leading-[1.5]'
-      transition:name={`${transitionPrefix}-title-${slug}`}
     >
       {metadata.title}
     </h2>

--- a/src/components/feature/content/related-articles.astro
+++ b/src/components/feature/content/related-articles.astro
@@ -30,11 +30,7 @@ const postsWithIcons = relatedPosts.map(({ post }) => {
       <h2 class='mb-8 text-2xl font-bold'>関連記事</h2>
       <div class='grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3'>
         {postsWithIcons.map(({ post, inlineSvg }) => (
-          <BlogCard
-            data={post}
-            inlineSvg={inlineSvg}
-            transitionPrefix='related'
-          />
+          <BlogCard data={post} inlineSvg={inlineSvg} />
         ))}
       </div>
     </section>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,7 +4,6 @@ import '@/styles/markdown.css';
 import { siteConfig } from '@/config/site';
 import { SOCIAL_CONSTANTS } from '@/constants';
 import { absoluteUrl } from '@/lib/utils';
-import { ClientRouter } from 'astro:transitions';
 import ThemeProvider from '@/components/ui/theme-provider.astro';
 import Header from '@/components/shared/Header';
 import { SearchDialog } from '@/components/feature/search/search-dialog';
@@ -59,10 +58,7 @@ const jsonLdWebsite = {
 ---
 
 <!doctype html>
-<html
-  lang='ja'
-  class='font-(family-name:--font-plemol-jp-35-console) overflow-x-hidden'
->
+<html lang='ja' class='overflow-x-hidden'>
   <head>
     <meta charset='UTF-8' />
     <meta name='viewport' content='width=device-width, initial-scale=1.0' />
@@ -145,8 +141,6 @@ const jsonLdWebsite = {
     />
 
     <ThemeProvider />
-
-    <ClientRouter />
 
     <script
       is:inline

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -162,10 +162,7 @@ const compiledHtml = await compileMarkdown({ source: post.body });
       </div>
       {
         (displayUrl || post.data.icon) && (
-          <div
-            class='mb-6 flex justify-center'
-            transition:name={`blog-icon-${slug}`}
-          >
+          <div class='mb-6 flex justify-center'>
             {inlineSvg ? (
               <span
                 class='h-20 w-20 [&>svg]:h-full [&>svg]:w-full [&>svg]:object-contain'
@@ -198,10 +195,7 @@ const compiledHtml = await compileMarkdown({ source: post.body });
           </address>
           {
             post.data.date && (
-              <div
-                class='inline-flex items-center gap-1'
-                transition:name={`blog-date-${slug}`}
-              >
+              <div class='inline-flex items-center gap-1'>
                 <Icons.Calendar client:load className='size-4' />
                 <time
                   datetime={post.data.date.toISOString()}
@@ -234,10 +228,7 @@ const compiledHtml = await compileMarkdown({ source: post.body });
       <div
         class='flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'
       >
-        <h1
-          class='text-2xl font-bold leading-snug tracking-normal'
-          transition:name={`blog-title-${slug}`}
-        >
+        <h1 class='text-2xl font-bold leading-snug tracking-normal'>
           {post.data.title}
         </h1>
         <div class='self-start sm:self-auto'>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -31,7 +31,7 @@
 
   /* フォントファミリー */
   --font-sans: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic Medium", "Yu Gothic", "Noto Sans CJK JP", sans-serif;
-  --font-mono: 'PlemolJP35Console', monospace;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
 
   /* コンテナ設定(v4ではCSS変数として定義) */
   --container-center: true;
@@ -241,15 +241,3 @@ mark {
   color: hsl(0 0% 100%) !important;
 }
 
-/* Custom font */
-@font-face {
-  font-family: 'PlemolJP35Console';
-  src: url('/fonts/PlemolJP35Console-Regular.woff2') format('woff2');
-  font-display: optional;
-  font-weight: normal;
-  font-style: normal;
-}
-
-:root {
-  --font-plemol-jp-35-console: 'PlemolJP35Console', monospace;
-}


### PR DESCRIPTION
## 概要

パフォーマンス改善のための変更。モバイルLighthouseでFCP 8.0s・LCP 8.9sが計測されており、主要ボトルネックを除去する。

## 変更内容

- **PlemolJP35Console(1.1MB)削除**: `@font-face`・CSS変数・`html`クラスを削除。`--font-mono`をシステムフォントスタック(`ui-monospace`, `SFMono-Regular`, `Menlo`, `Consolas`等)に変更
- **ClientRouter(View Transitions)削除**: 強制リフロー240msの原因を除去。ページ遷移は通常のフルリロードに戻る
- **transition:name属性削除**: `blog-card`・`blog/[slug]`・`related-articles`から全削除
- **transitionPrefix prop削除**: `blog-card`の型定義・デストラクチャリングから除去

## 期待される効果

| 項目 | 改善内容 |
|------|----------|
| PlemolJP35Console | 1.1MBフォントダウンロードが消滅（遅い4Gで約7秒分の帯域を占有していた） |
| ClientRouter JS | 強制リフロー240ms除去、JSバンドル削減 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)