### PR TITLE
fix: Header・SearchDialogをclient:idle→client:visibleに変更

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -164,8 +164,8 @@ const jsonLdWebsite = {
     </a>
     <div aria-hidden class='pointer-events-none fixed inset-0 -z-10 opacity-20'>
     </div>
-    <Header pathname={pathname} client:idle />
-    <SearchDialog pathname={pathname} client:idle />
+    <Header pathname={pathname} client:visible />
+    <SearchDialog pathname={pathname} client:visible />
     <main
       id='main-content'
       class='mx-auto w-full max-w-6xl flex-1 px-4 py-12 sm:px-6 md:px-8'


### PR DESCRIPTION
## 概要

iOS Safariで`client:idle`のアイドルコールバックが13秒以上遅延する問題を修正。

## 原因

HARファイル分析により、リクエストが2グループに分断されていることを確認。

- 第1グループ: 0ms〜60ms（HTML・CSS・React本体）
- **13秒の空白**
- 第2グループ: 13,032ms〜（Header・SearchDialog・その他）

`client:idle`は`requestIdleCallback`を使用するが、iOS Safariではバッテリー管理・サーマルスロットリングの影響でアイドル判定が大幅に遅延することがある。

## 変更内容

- `Header`: `client:idle` → `client:visible`
- `SearchDialog`: `client:idle` → `client:visible`

`client:visible`はIntersectionObserverベースのため、常時Viewport内に存在するHeaderはページ表示直後に確実にハイドレーションされる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)