### PR TITLE
fix: 残りのclient:idleをclient:visibleに変更

### DIFF
--- a/src/components/feature/content/markdown-content.astro
+++ b/src/components/feature/content/markdown-content.astro
@@ -12,6 +12,6 @@ const { html } = Astro.props;
 
 <div class='markdown-content' set:html={html} />
 
-<CodeCopyButtons client:idle />
-<ImageZoom client:idle />
-<TwitterWidgets client:idle />
+<CodeCopyButtons client:visible />
+<ImageZoom client:visible />
+<TwitterWidgets client:visible />

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -232,7 +232,7 @@ const compiledHtml = await compileMarkdown({ source: post.body });
           {post.data.title}
         </h1>
         <div class='self-start sm:self-auto'>
-          <MarkdownCopyButton client:idle content={post.body} />
+          <MarkdownCopyButton client:visible content={post.body} />
         </div>
       </div>
       {


### PR DESCRIPTION
## 概要

iOS SafariでHARファイル分析により判明した13秒遅延問題の完全解消。
前PRでHeader・SearchDialogを対応済み。本PRで残りの`client:idle`を全て除去する。

## 変更内容

- `CodeCopyButtons`: `client:idle` → `client:visible`
- `ImageZoom`: `client:idle` → `client:visible`
- `TwitterWidgets`: `client:idle` → `client:visible`
- `MarkdownCopyButton`: `client:idle` → `client:visible`

これにより`client:idle`がコードベースから完全になくなる。

## 原因の詳細

SafariはiOSを含め`requestIdleCallback`をデフォルト非対応（機能フラグ裏）。
Astroは`setTimeout`にフォールバックするが、iOS省電力管理でこのタイマーが
13秒以上遅延することがある。

`client:visible`はIntersectionObserverベースのため、
要素がViewportに入った瞬間に確実にハイドレーションされる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)