### PR TITLE
perf: ヒーローセクションのblur要素を削除

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -54,14 +54,6 @@ const canonicalUrl = absoluteUrl('/');
   <section data-pagefind-ignore class='space-y-16 pt-16'>
     <!-- Hero -->
     <div class='relative mx-auto max-w-3xl text-center animate-fade-in-bottom'>
-      <div
-        class='pointer-events-none absolute left-1/2 top-1/2 -z-10 h-[320px] w-[320px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary/15 blur-[110px] animate-float'
-      >
-      </div>
-      <div
-        class='pointer-events-none absolute left-1/3 top-1/3 -z-20 h-48 w-48 -translate-x-1/2 -translate-y-1/2 rounded-full bg-accent/30 blur-[90px] animate-float'
-      >
-      </div>
       <h1
         class='flex flex-wrap items-center justify-center gap-x-6 text-center text-4xl font-bold leading-tight tracking-tight md:flex-nowrap md:text-5xl font-mono'
       >


### PR DESCRIPTION
## 概要

iOS Safariで白画面が10秒続く問題の原因調査のための変更。

## 変更内容

- `blur-[110px]`（320×320px）と `blur-[90px]`（192×192px）の背景装飾要素を完全削除

## 背景

本日の調査で以下の問題を順次解消したが、白画面10秒の問題が残存：
- Cloudflare Fonts インライン化（374KB）→ 無効化済み
- Google Fonts レンダーブロック（1,530ms）→ 削除済み
- PlemolJP35Console（1.1MB）→ 削除済み
- ClientRouter 強制リフロー→ 削除済み
- client:idle iOS遅延（13秒）→ client:visibleに変更済み
- Cloudflare JS Detection（12秒）→ API経由で無効化済み

消去法の結果、GPU描画コストの高いCSSブラーが最後の仮説として残った。
`filter: blur(110px)` はモバイルGPUで描画前に長時間の計算を要する可能性がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)